### PR TITLE
refactor: 优化弱网探测流程

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 __pycache__/
 *.py[cod]
 .venv/
+AGENTS.md
+COLLABORATION.md
+.mypy_cache
 outputs/*.png
 _debug/screenshots/*.png
 _debug/screenshots/run_debug/*.png

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,16 @@
 __pycache__/
 *.py[cod]
 .venv/
-AGENTS.md
-COLLABORATION.md
 .mypy_cache
 outputs/*.png
 _debug/screenshots/*.png
 _debug/screenshots/run_debug/*.png
 _debug/logs/*.log
+
+AGENTS.md
+COLLABORATION.md
+.codex
+.agents
 
 save_points/dbg
 _screen.png

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@
 │   ├── image_match.py         # 模板匹配
 │   ├── diamond_centers.py     # 菱形网格检测与中心点计算
 │   ├── diamond_hit.py         # 点击前后截图对比与命中判断
+│   ├── hit_map.py             # 命中矩阵投影与可视化图片输出
+│   ├── probe_protocol.py      # 单次弱网探测状态机与安全转换
 │   ├── submarine_strategy.py  # 潜艇搜索策略、确认和安全区推断
 │   └── logger.py              # 日志配置
 ├── tests/                     # 策略和主流程单元测试

--- a/main.py
+++ b/main.py
@@ -1,28 +1,50 @@
 import atexit
 import signal
-import time
 from pathlib import Path
-from time import sleep
+from time import monotonic, sleep
 
-import cv2
 import numpy as np
 
 from config import (
     GAME_PACKAGE_NAME,
     LEVEL_GRID_SIZES,
     OUTPUT_DIR,
+    SCREENSHOT_DIR,
     SUBMARINES,
+    TEMPLATE_DIR,
     USE_SAVED_POINTS,
 )
 from save_points.points import read_saved_points, read_saved_quad
 from utils import AdbController, MatchResult, find_template, get_logger, is_diamond_hit
-from utils.diamond_centers import detect_diamond_centers, write_image
+from utils.diamond_centers import detect_diamond_centers
+from utils.hit_map import save_hit_map_image
+from utils.probe_protocol import (
+    ProbeNotReadyError,
+    ProbePhase,
+    ProbeProtocolError,
+    ProbeTransaction,
+)
 from utils.submarine_strategy import Cell, SubmarineStrategy, get_configured_submarines
 
 logger = get_logger(__name__)
 adb = AdbController()
+
+ACTIVITY_BUTTON_TEMPLATE = TEMPLATE_DIR / "activity_button.png"
+LOGIN_TEMPLATE = TEMPLATE_DIR / "login.png"
+QUIT_ACTIVITY_TEMPLATE = TEMPLATE_DIR / "quit_activity.png"
+RETRY_TEMPLATE = TEMPLATE_DIR / "retry.png"
+
+ACTIVITY_DETAIL_POINT = (1205, 644)
+ACTIVITY_LIST_SWIPE = (1000, 660, 1000, 180)
+RUN_DEBUG_DIR = SCREENSHOT_DIR / "run_debug"
+
 _weak_network_cleanup_done = False
-    
+_active_probe: "ProbeTransaction | None" = None
+
+
+def _has_pending_probe_request() -> bool:
+    return _active_probe is not None and _active_probe.request_may_be_pending
+
 
 def enable_weak_network(second: float = 0) -> None:
     """开启游戏弱网，并按需等待网络状态生效。"""
@@ -30,24 +52,45 @@ def enable_weak_network(second: float = 0) -> None:
     if second > 0:
         sleep(second)
 
+
 def disable_weak_network(second: float = 0) -> None:
-    """关闭游戏弱网，并按需等待网络状态恢复。"""
+    """安全关闭游戏弱网；存在待丢弃请求时拒绝恢复网络。"""
+    if _has_pending_probe_request():
+        transaction = _active_probe
+        raise ProbeProtocolError(
+            "客户端仍可能保存待发送请求，拒绝关闭 DROP 弱网："
+            f"cell={transaction.cell if transaction else None} "
+            f"phase={transaction.phase.name if transaction else None}"
+        )
     adb.disable_weak_network(GAME_PACKAGE_NAME)
     if second > 0:
         sleep(second)
 
+
 def cleanup_weak_network(reason: str = "脚本退出") -> None:
-    """脚本退出时关闭游戏弱网，防止影响游戏正常运行"""
+    """仅在不存在待发送探测请求时关闭 DROP 弱网。"""
     global _weak_network_cleanup_done
     if _weak_network_cleanup_done:
         return
 
-    _weak_network_cleanup_done = True
+    if _has_pending_probe_request():
+        transaction = _active_probe
+        logger.critical(
+            "%s，但格子 %s 的探测处于 %s；为避免暂存请求补发，保留 DROP 弱网",
+            reason,
+            transaction.cell if transaction else None,
+            transaction.phase.name if transaction else None,
+        )
+        return
+
     try:
         logger.info("%s，正在关闭弱网", reason)
         disable_weak_network()
     except Exception as exc:
         logger.error("关闭弱网失败: %s", exc)
+    else:
+        _weak_network_cleanup_done = True
+
 
 def cleanup_reject_network(reason: str = "脚本退出") -> None:
     """关闭游戏 REJECT 断网残留，避免影响本次或下次运行。"""
@@ -57,10 +100,12 @@ def cleanup_reject_network(reason: str = "脚本退出") -> None:
     except Exception as exc:
         logger.error("清理 REJECT 断网失败: %s", exc)
 
+
 def handle_exit_signal(signum: int, _frame) -> None:
     """收到退出信号时先关闭弱网再退出。"""
     cleanup_weak_network(f"收到退出信号 {signum}")
     raise SystemExit(128 + signum)
+
 
 def register_exit_cleanup() -> None:
     """注册脚本退出清理，尽量避免弱网规则残留。"""
@@ -70,16 +115,27 @@ def register_exit_cleanup() -> None:
         if signum is not None:
             signal.signal(signum, handle_exit_signal)
 
+
 def enter_activity(re_enter: bool = False, max_retries: int = 5) -> None:
+    """进入活动详情页。
+
+    ``re_enter=False`` 用于没有待验证请求的普通进入，允许重启恢复；
+    ``re_enter=True`` 用于点击后的第二次进入，此时 DROP 下可能仍有暂存请求，
+    任何失败都必须立即中止，不能复用会关闭弱网的普通恢复流程。
+    """
     if max_retries <= 0:
         raise ValueError(f"max_retries 必须大于 0: {max_retries}")
 
     last_failure = "进入活动失败"
     for attempt in range(1, max_retries + 1):
         adb.delay(0.5)
-        res = wait_until_occur("./template/activity_button.png", timeout=20)
+        res = wait_until_occur(ACTIVITY_BUTTON_TEMPLATE, timeout=20)
         if res is None:
             last_failure = "未找到活动按钮"
+            if re_enter:
+                raise ProbeProtocolError(
+                    f"第二次进入活动时{last_failure}；保留 DROP 弱网并中止探测"
+                )
             logger.warning(
                 "%s，无法进入活动界面，正在重试 (%s/%s)",
                 last_failure,
@@ -89,17 +145,21 @@ def enter_activity(re_enter: bool = False, max_retries: int = 5) -> None:
             _restart_game_for_activity_retry()
             continue
 
-        adb.click(*res.center) # 点击活动按钮进入活动界面
-        if not re_enter or attempt > 1:
+        adb.click(*res.center)  # 点击活动按钮进入活动界面
+        if not re_enter:
             enable_weak_network(0.2)
-            adb.delay(0.4).swipe(1000, 660, 1000, 180) # 上滑展示全部选项（仅第一次进入需要）
-            adb.delay(0.2).swipe(1000, 660, 1000, 180)
+            adb.delay(0.4).swipe(*ACTIVITY_LIST_SWIPE)  # 首次进入需要展示全部选项
+            adb.delay(0.2).swipe(*ACTIVITY_LIST_SWIPE)
 
-        adb.delay(0.7).click(1205, 644) # 点击进入活动详情界面
-        if wait_until_occur("./template/quit_activity.png", timeout=15) is not None:
+        adb.delay(0.7).click(*ACTIVITY_DETAIL_POINT)
+        if wait_until_occur(QUIT_ACTIVITY_TEMPLATE, timeout=15) is not None:
             return
 
         last_failure = "进入活动详情界面失败"
+        if re_enter:
+            raise ProbeProtocolError(
+                f"第二次进入活动时{last_failure}；保留 DROP 弱网并中止探测"
+            )
         logger.warning(
             "%s，正在重试进入活动 (%s/%s)",
             last_failure,
@@ -114,91 +174,19 @@ def enter_activity(re_enter: bool = False, max_retries: int = 5) -> None:
 
 
 def _restart_game_for_activity_retry() -> None:
+    """在没有待验证请求的普通进入阶段重启游戏。"""
+    if _has_pending_probe_request():
+        raise ProbeProtocolError("存在待发送探测请求，禁止通过重启游戏恢复活动入口")
+
     adb.close_app(GAME_PACKAGE_NAME)
     adb.disable_reject_network(GAME_PACKAGE_NAME)
     disable_weak_network()
     adb.delay(1.5).open_app(GAME_PACKAGE_NAME)
-    login_img = wait_until_occur("./template/login.png", timeout=30)
+    login_img = wait_until_occur(LOGIN_TEMPLATE, timeout=30)
     if login_img is None:
         logger.warning("重新启动游戏后未找到登录按钮，继续下一次进入尝试")
         return
-    adb.click(*login_img.center) # 点击登录按钮
-    
-
-def _build_cell_polygons(quad: np.ndarray, n: int) -> list[list[np.ndarray]]:
-    """根据外层菱形四角生成每个方格的四边形坐标。"""
-    src = np.array(
-        [
-            [0, 0],
-            [n, 0],
-            [n, n],
-            [0, n],
-        ],
-        dtype=np.float32,
-    )
-    matrix = cv2.getPerspectiveTransform(src, quad.astype(np.float32))
-    polygons: list[list[np.ndarray]] = []
-
-    for row in range(n):
-        polygon_row: list[np.ndarray] = []
-        for col in range(n):
-            cell = np.array(
-                [
-                    [[col, row]],
-                    [[col + 1, row]],
-                    [[col + 1, row + 1]],
-                    [[col, row + 1]],
-                ],
-                dtype=np.float32,
-            )
-            projected = cv2.perspectiveTransform(cell, matrix).reshape(4, 2)
-            polygon_row.append(np.round(projected).astype(np.int32))
-        polygons.append(polygon_row)
-
-    return polygons
-
-
-def save_hit_map_image(
-    base_img: np.ndarray,
-    quad: np.ndarray,
-    hit_map: list[list[int]],
-    out_path: str | Path,
-) -> None:
-    """把命中结果叠加绘制到游戏截图上并保存。"""
-    n = len(hit_map)
-    if n == 0 or any(len(row) != n for row in hit_map):
-        raise ValueError("hit_map 必须是非空的 N x N 列表")
-
-    out = base_img.copy()
-    overlay = out.copy()
-    polygons = _build_cell_polygons(quad, n)
-
-    for row in range(n):
-        for col in range(n):
-            if hit_map[row][col] == 1:
-                cv2.fillConvexPoly(
-                    overlay,
-                    polygons[row][col],
-                    (0, 0, 255),
-                    lineType=cv2.LINE_AA,
-                )
-
-    out = cv2.addWeighted(overlay, 0.38, out, 0.62, 0)
-
-    for row in range(n):
-        for col in range(n):
-            is_hit_cell = hit_map[row][col] == 1
-            cv2.polylines(
-                out,
-                [polygons[row][col]],
-                True,
-                (0, 0, 255) if is_hit_cell else (255, 255, 255),
-                3 if is_hit_cell else 1,
-                cv2.LINE_AA,
-            )
-
-    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
-    write_image(out_path, out)
+    adb.click(*login_img.center)  # 点击登录按钮
 
 
 def get_level_grid_size(level: int) -> int:
@@ -208,7 +196,9 @@ def get_level_grid_size(level: int) -> int:
     return LEVEL_GRID_SIZES[level]
 
 
-def get_click_points(level: int, grid_img: np.ndarray) -> tuple[list[tuple[int, int]], np.ndarray]:
+def get_click_points(
+    level: int, grid_img: np.ndarray
+) -> tuple[list[tuple[int, int]], np.ndarray]:
     """按配置读取人工点位，失败时回退到自动识别。"""
     grid_size = get_level_grid_size(level)
 
@@ -229,11 +219,11 @@ def get_click_points(level: int, grid_img: np.ndarray) -> tuple[list[tuple[int, 
     return grid_result.points, grid_result.global_quad
 
 
-def handle_game_level(level: int, hit_map: list[list[int]]) -> tuple[np.ndarray, np.ndarray]:
+def handle_game_level(
+    level: int, hit_map: list[list[int]]
+) -> tuple[np.ndarray, np.ndarray]:
     """处理单个关卡：有潜艇配置时策略选点，缺少配置时回退逐格扫描。"""
-    # 获取当前关卡的棱形方格中心坐标列表
     adb.delay(1.5)
-    # adb.pinch_in(distance=10, duration_ms=200) # 缩小视野，目前不需要
     grid_img = adb.read_screenshot()
     click_points, grid_quad = get_click_points(level, grid_img)
 
@@ -257,7 +247,7 @@ def _scan_level_by_grid_order(
     """按行优先顺序逐格探测，可跳过策略阶段已获得真实反馈的格子。"""
     grid_size = get_level_grid_size(level)
     skip_cells = skip_cells or set()
-    for index, point in enumerate(click_points): # 遍历每个方格中心坐标
+    for index, point in enumerate(click_points):
         cell = (index // grid_size, index % grid_size)
         if cell in skip_cells:
             continue
@@ -276,7 +266,9 @@ def _scan_level_by_strategy(
     max_attempts = grid_size * grid_size
     attempts = 0
 
-    logger.info("第 %s 关启用潜艇策略：grid=%s submarines=%s", level, grid_size, submarines)
+    logger.info(
+        "第 %s 关启用潜艇策略：grid=%s submarines=%s", level, grid_size, submarines
+    )
 
     while not strategy.done and attempts < max_attempts:
         cell = strategy.choose_next_cell()
@@ -288,17 +280,19 @@ def _scan_level_by_strategy(
         index = row * grid_size + col
         hit = _probe_cell(level, hit_map, cell, click_points[index], index)
         attempts += 1
-
-        if hit is None:
-            continue
-
         strategy.report_result(cell, hit)
 
     if strategy.done:
         logger.info("第 %s 关策略已确认全部潜艇，探测次数：%s", level, attempts)
     else:
         logger.warning("第 %s 关策略未能确认全部潜艇，回退逐格扫描未探测方格", level)
-        _scan_level_by_grid_order(level, hit_map, click_points, skip_cells=set(strategy.shots))
+        known_cells = set(strategy.shots) | strategy.blocked_cells
+        _scan_level_by_grid_order(
+            level,
+            hit_map,
+            click_points,
+            skip_cells=known_cells,
+        )
 
 
 def _probe_cell(
@@ -307,53 +301,132 @@ def _probe_cell(
     cell: Cell,
     point: tuple[int, int],
     index: int,
-) -> bool | None:
-    """执行一次单格探测，保持原自动化顺序；命中返回 True，未命中返回 False，页面异常返回 None。"""
+) -> bool:
+    """准备页面并执行一次完整探测；点击前异常只重试当前格。"""
+    max_preflight_retries = 3
+    for attempt in range(1, max_preflight_retries + 1):
+        try:
+            return _execute_probe_transaction(level, hit_map, cell, point, index)
+        except ProbeNotReadyError as exc:
+            if attempt >= max_preflight_retries:
+                raise ProbeProtocolError(
+                    f"格子 {cell} 在点击前连续 {max_preflight_retries} 次未准备好"
+                ) from exc
+            logger.warning(
+                "格子 %s 点击前页面未准备好，恢复后重试同一格 (%s/%s)：%s",
+                cell,
+                attempt,
+                max_preflight_retries,
+                exc,
+            )
+            enter_activity()
+
+    raise AssertionError("探测重试循环意外结束")
+
+
+def _execute_probe_transaction(
+    level: int,
+    hit_map: list[list[int]],
+    cell: Cell,
+    point: tuple[int, int],
+    index: int,
+) -> bool:
+    """按固定 DROP/二次进入/REJECT/登录顺序执行单格探测事务。"""
+    global _active_probe
+
+    if _active_probe is not None:
+        raise ProbeProtocolError(
+            f"上一轮探测尚未结束，禁止开始格子 {cell}: "
+            f"cell={_active_probe.cell} phase={_active_probe.phase.name}"
+        )
+
+    if wait_until_occur(QUIT_ACTIVITY_TEMPLATE, timeout=6) is None:
+        raise ProbeNotReadyError("当前不在活动详情界面")
+
+    transaction = ProbeTransaction(level=level, cell=cell, index=index)
+    _active_probe = transaction
     x, y = point
-    # if i != 0:
-    #     adb.pinch_in(distance=10, duration_ms=200)
-    if wait_until_occur("./template/quit_activity.png", timeout=6) is None:
-        logger.warning("点击方格前不在活动详情界面，重新进入活动后跳过本次点击")
-        enter_activity()
-        return None
 
-    before_img = adb.read_screenshot("./_debug/screenshots/run_debug/debug_before.png") # 点击前截图
-    adb.click(x, y)
-    adb.delay(0.3)
-    if not click_template("./template/quit_activity.png", "./_debug/screenshots/run_debug/debug_quit1.png"):
-        logger.warning("点击方格后未找到退出按钮，当前页面可能已离开活动详情界面")
-        enter_activity()
-        return None
+    try:
+        before_img = adb.read_screenshot(RUN_DEBUG_DIR / "debug_before.png")
 
-    enter_activity(re_enter=True) # 重新进入活动界面
-    # adb.pinch_in(distance=10, duration_ms=200)
-    after_img = adb.delay(1).read_screenshot("./_debug/screenshots/run_debug/debug_after.png")
-    if is_diamond_hit(before_img, after_img, (x, y)):
-        row, col = cell
-        hit_map[row][col] = 1
-        logger.info("第 %s 关，点击方格 %s 结果：击中！", level, index)
-        hit = True
-    else:
-        logger.info("第 %s 关，点击方格 %s 结果：未击中", level, index)
-        hit = False
+        # 点击命令一旦发出，就保守地认为客户端可能已经暂存验证请求。
+        transaction.advance(ProbePhase.REQUEST_PENDING)
+        adb.click(x, y)
+        adb.delay(0.3)
 
+        if not click_template(
+            QUIT_ACTIVITY_TEMPLATE,
+            RUN_DEBUG_DIR / "debug_quit1.png",
+        ):
+            raise ProbeProtocolError(
+                "点击格子后未找到退出按钮；待发送请求状态未知，保留 DROP 弱网"
+            )
+
+        enter_activity(re_enter=True, max_retries=1)
+        after_img = adb.delay(1).read_screenshot(RUN_DEBUG_DIR / "debug_after.png")
+        transaction.advance(ProbePhase.RESULT_VISIBLE)
+
+        hit = is_diamond_hit(before_img, after_img, (x, y))
+        transaction.hit = hit
+        transaction.advance(ProbePhase.RESULT_RECORDED)
+
+        if hit:
+            row, col = cell
+            hit_map[row][col] = 1
+            logger.info("第 %s 关，点击方格 %s 结果：击中！", level, index)
+        else:
+            logger.info("第 %s 关，点击方格 %s 结果：未击中", level, index)
+
+        _discard_pending_request_and_prepare_next_probe(transaction)
+        return hit
+    finally:
+        if transaction.phase in {ProbePhase.PREPARING, ProbePhase.COMPLETE}:
+            _active_probe = None
+        elif transaction.request_may_be_pending:
+            logger.critical(
+                "格子 %s 的探测中断于 %s；客户端可能仍有暂存请求，"
+                "退出清理将保留 DROP 弱网",
+                transaction.cell,
+                transaction.phase.name,
+            )
+
+
+def _discard_pending_request_and_prepare_next_probe(
+    transaction: ProbeTransaction,
+) -> None:
+    """通过 REJECT 丢弃暂存请求，恢复登录并准备下一轮。"""
     adb.enable_reject_network(GAME_PACKAGE_NAME)
-    retry = wait_until_occur("./template/retry.png", timeout=20)
+    retry = wait_until_occur(RETRY_TEMPLATE, timeout=20)
+    if retry is None:
+        raise ProbeProtocolError(
+            "REJECT 后未出现重试按钮；无法确认暂存请求已丢弃，保留网络阻断"
+        )
+
+    # retry 出现表示客户端已确认网络失败并丢弃本轮暂存请求。
+    transaction.advance(ProbePhase.REQUEST_DISCARDED)
     adb.disable_reject_network(GAME_PACKAGE_NAME)
-    adb.delay(0.8).click(*retry.center) # 点击重试按钮
+    adb.delay(0.8).click(*retry.center)
+    transaction.advance(ProbePhase.LOGIN_RECOVERING)
 
     restart_process()
-    return hit
-        
-def restart_process():
+    transaction.advance(ProbePhase.COMPLETE)
+
+
+def restart_process() -> None:
+    """在请求确认丢弃后恢复网络登录，并进入下一轮探测页面。"""
     disable_weak_network()
     enter_activity()
-        
-def wait_until_occur(template_path: str, timeout: float = 30.0) -> MatchResult | None:
+
+
+def wait_until_occur(
+    template_path: str | Path,
+    timeout: float = 30.0,
+) -> MatchResult | None:
     """等待直到指定模板出现，返回匹配结果或 None（超时）。"""
     logger.info("正在等待模板 '%s' 出现，超时时间 %s 秒...", template_path, timeout)
-    start_time = time.time()
-    while time.time() - start_time < timeout:
+    start_time = monotonic()
+    while monotonic() - start_time < timeout:
         screenshot = adb.read_screenshot()
         match_result = find_template(screenshot, template_path)
         if match_result is not None:
@@ -362,7 +435,12 @@ def wait_until_occur(template_path: str, timeout: float = 30.0) -> MatchResult |
     logger.warning("等待模板 '%s' 超时 (%s 秒)", template_path, timeout)
     return None
 
-def click_template(template_path: str, screenshot_path: str | None = None, threshold: float = 0.85) -> bool:
+
+def click_template(
+    template_path: str | Path,
+    screenshot_path: str | Path | None = None,
+    threshold: float = 0.85,
+) -> bool:
     """查找模板并点击中心点，找不到时返回 False。"""
     img = adb.read_screenshot(screenshot_path)
     match_result = find_template(img, template_path, threshold=threshold)
@@ -372,26 +450,29 @@ def click_template(template_path: str, screenshot_path: str | None = None, thres
     adb.delay(0.5).click(*match_result.center)
     return True
 
-def main(level: int):
+
+def main(level: int) -> Path | None:
+    """执行指定关卡的逻辑探测并输出命中图。"""
     grid_size = get_level_grid_size(level)
-    hit_map = [[0 for i in range(grid_size)] for j in range(grid_size)]
+    hit_map = [[0] * grid_size for _ in range(grid_size)]
     disable_weak_network()
-    
-    if not find_template(adb.read_screenshot(), "./template/activity_button.png"):
+
+    if find_template(adb.read_screenshot(), ACTIVITY_BUTTON_TEMPLATE) is None:
         logger.error("当前不在海岛主界面，无法启动脚本")
-        return
-    
+        return None
+
     enter_activity()
     base_img, quad = handle_game_level(level, hit_map)
     out_path = OUTPUT_DIR / f"hit_map_level_{level}.png"
     save_hit_map_image(base_img, quad, hit_map, out_path)
     logger.info("命中矩阵：%s", hit_map)
     logger.info("命中可视化图片已保存：%s", out_path)
-    
+    return out_path
+
 
 if __name__ == "__main__":
     register_exit_cleanup()
-    level = 1
+    level = 2
     try:
         adb.ensure_root_shell()
         cleanup_reject_network("主流程启动")
@@ -399,4 +480,3 @@ if __name__ == "__main__":
     finally:
         cleanup_weak_network("主流程结束")
         cleanup_reject_network("主流程结束")
-    

--- a/tests/test_hit_map.py
+++ b/tests/test_hit_map.py
@@ -1,0 +1,36 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from utils.hit_map import save_hit_map_image
+
+
+class HitMapTest(unittest.TestCase):
+    def test_save_hit_map_image_writes_red_hit_overlay(self):
+        base = np.zeros((120, 120, 3), dtype=np.uint8)
+        quad = np.array(
+            [[60, 10], [110, 60], [60, 110], [10, 60]],
+            dtype=np.float32,
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "hit_map.png"
+            save_hit_map_image(base, quad, [[1, 0], [0, 0]], output)
+            rendered = cv2.imread(str(output))
+
+        self.assertIsNotNone(rendered)
+        self.assertGreater(int(np.count_nonzero(rendered[:, :, 2])), 0)
+
+    def test_save_hit_map_image_rejects_non_square_map(self):
+        base = np.zeros((20, 20, 3), dtype=np.uint8)
+        quad = np.zeros((4, 2), dtype=np.float32)
+
+        with self.assertRaisesRegex(ValueError, "N x N"):
+            save_hit_map_image(base, quad, [[1, 0], [0]], "unused.png")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -25,12 +25,25 @@ class FakeAdb:
     def click(self, x, y):
         self.calls.append(("click", x, y))
 
+    def read_screenshot(self, output_path=None):
+        self.calls.append(("read_screenshot", output_path))
+        return object()
+
     def swipe(self, start_x, start_y, end_x, end_y):
         self.calls.append(("swipe", start_x, start_y, end_x, end_y))
         return self
 
     def enable_weak_network(self, package_name):
         self.calls.append(("enable_weak_network", package_name))
+
+    def disable_weak_network(self, package_name):
+        self.calls.append(("disable_weak_network", package_name))
+
+    def enable_reject_network(self, package_name):
+        self.calls.append(("enable_reject_network", package_name))
+
+    def disable_reject_network(self, package_name):
+        self.calls.append(("disable_reject_network", package_name))
 
 
 class DummyMatch:
@@ -63,7 +76,11 @@ class MainFlowTest(unittest.TestCase):
             ]
         )
 
-        with patch.object(self.main, "wait_until_occur", side_effect=lambda *args, **kwargs: next(waits)):
+        with patch.object(
+            self.main,
+            "wait_until_occur",
+            side_effect=lambda *args, **kwargs: next(waits),
+        ):
             self.main.enter_activity(max_retries=2)
 
         package_name = self.main.GAME_PACKAGE_NAME
@@ -75,7 +92,8 @@ class MainFlowTest(unittest.TestCase):
         self.assertEqual(self.adb.calls.count(("enable_weak_network", package_name)), 1)
         self.assertEqual(
             [
-                call for call in self.adb.calls
+                call
+                for call in self.adb.calls
                 if call == ("swipe", 1000, 660, 1000, 180)
             ],
             [
@@ -101,7 +119,11 @@ class MainFlowTest(unittest.TestCase):
             ]
         )
 
-        with patch.object(self.main, "wait_until_occur", side_effect=lambda *args, **kwargs: next(waits)):
+        with patch.object(
+            self.main,
+            "wait_until_occur",
+            side_effect=lambda *args, **kwargs: next(waits),
+        ):
             self.main.enter_activity(re_enter=True, max_retries=1)
 
         package_name = self.main.GAME_PACKAGE_NAME
@@ -109,6 +131,150 @@ class MainFlowTest(unittest.TestCase):
         self.assertNotIn(("swipe", 1000, 660, 1000, 180), self.adb.calls)
         self.assertIn(("click", 30, 40), self.adb.calls)
         self.assertIn(("click", 1205, 644), self.adb.calls)
+
+    def test_re_enter_failure_does_not_use_normal_restart_recovery(self):
+        with patch.object(self.main, "wait_until_occur", return_value=None):
+            with self.assertRaisesRegex(
+                self.main.ProbeProtocolError,
+                "第二次进入活动",
+            ):
+                self.main.enter_activity(re_enter=True, max_retries=1)
+
+        package_name = self.main.GAME_PACKAGE_NAME
+        self.assertNotIn(("close_app", package_name), self.adb.calls)
+        self.assertNotIn(("open_app", package_name), self.adb.calls)
+        self.assertNotIn(("disable_weak_network", package_name), self.adb.calls)
+
+    def test_cleanup_keeps_drop_when_probe_request_may_be_pending(self):
+        transaction = self.main.ProbeTransaction(level=1, cell=(0, 0), index=0)
+        transaction.advance(self.main.ProbePhase.REQUEST_PENDING)
+        self.main._active_probe = transaction
+
+        self.main.cleanup_weak_network("测试清理")
+
+        package_name = self.main.GAME_PACKAGE_NAME
+        self.assertNotIn(("disable_weak_network", package_name), self.adb.calls)
+        self.assertFalse(self.main._weak_network_cleanup_done)
+
+    def test_probe_transaction_preserves_network_order(self):
+        waits = iter(
+            [
+                DummyMatch((1, 1)),  # 点击前已在详情页
+                DummyMatch((10, 20)),  # 第二次进入：活动按钮
+                DummyMatch((30, 40)),  # 第二次进入：详情页
+                DummyMatch((50, 60)),  # REJECT 后的重试按钮
+                DummyMatch((70, 80)),  # 登录后下一轮：活动按钮
+                DummyMatch((90, 100)),  # 登录后下一轮：详情页
+            ]
+        )
+        hit_map = [[0, 0], [0, 0]]
+
+        with (
+            patch.object(
+                self.main,
+                "wait_until_occur",
+                side_effect=lambda *args, **kwargs: next(waits),
+            ),
+            patch.object(self.main, "click_template", return_value=True),
+            patch.object(self.main, "is_diamond_hit", return_value=True),
+        ):
+            result = self.main._probe_cell(
+                level=1,
+                hit_map=hit_map,
+                cell=(0, 1),
+                point=(400, 300),
+                index=1,
+            )
+
+        package_name = self.main.GAME_PACKAGE_NAME
+        network_calls = [
+            call
+            for call in self.adb.calls
+            if call[0]
+            in {
+                "enable_reject_network",
+                "disable_reject_network",
+                "disable_weak_network",
+                "enable_weak_network",
+            }
+        ]
+        self.assertTrue(result)
+        self.assertEqual(hit_map[0][1], 1)
+        self.assertIsNone(self.main._active_probe)
+        self.assertEqual(
+            network_calls,
+            [
+                ("enable_reject_network", package_name),
+                ("disable_reject_network", package_name),
+                ("disable_weak_network", package_name),
+                ("enable_weak_network", package_name),
+            ],
+        )
+
+    def test_missing_retry_keeps_probe_pending_and_does_not_restore_drop(self):
+        waits = iter(
+            [
+                DummyMatch((1, 1)),  # 点击前已在详情页
+                DummyMatch((10, 20)),  # 第二次进入：活动按钮
+                DummyMatch((30, 40)),  # 第二次进入：详情页
+                None,  # REJECT 后没有重试按钮
+            ]
+        )
+        hit_map = [[0, 0], [0, 0]]
+
+        with (
+            patch.object(
+                self.main,
+                "wait_until_occur",
+                side_effect=lambda *args, **kwargs: next(waits),
+            ),
+            patch.object(self.main, "click_template", return_value=True),
+            patch.object(self.main, "is_diamond_hit", return_value=False),
+        ):
+            with self.assertRaisesRegex(
+                self.main.ProbeProtocolError,
+                "未出现重试按钮",
+            ):
+                self.main._probe_cell(
+                    level=1,
+                    hit_map=hit_map,
+                    cell=(0, 1),
+                    point=(400, 300),
+                    index=1,
+                )
+
+        package_name = self.main.GAME_PACKAGE_NAME
+        self.assertIsNotNone(self.main._active_probe)
+        self.assertTrue(self.main._active_probe.request_may_be_pending)
+        self.assertIn(("enable_reject_network", package_name), self.adb.calls)
+        self.assertNotIn(("disable_weak_network", package_name), self.adb.calls)
+
+    def test_preflight_failure_retries_the_same_cell(self):
+        hit_map = [[0, 0], [0, 0]]
+
+        with (
+            patch.object(
+                self.main,
+                "_execute_probe_transaction",
+                side_effect=[
+                    self.main.ProbeNotReadyError("页面未准备好"),
+                    False,
+                ],
+            ) as execute,
+            patch.object(self.main, "enter_activity") as recover,
+        ):
+            result = self.main._probe_cell(
+                level=1,
+                hit_map=hit_map,
+                cell=(0, 1),
+                point=(400, 300),
+                index=1,
+            )
+
+        self.assertFalse(result)
+        self.assertEqual(execute.call_count, 2)
+        self.assertEqual(execute.call_args_list[0], execute.call_args_list[1])
+        recover.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/tests/test_probe_protocol.py
+++ b/tests/test_probe_protocol.py
@@ -1,0 +1,40 @@
+import unittest
+
+from utils.probe_protocol import (
+    ProbePhase,
+    ProbeProtocolError,
+    ProbeTransaction,
+)
+
+
+class ProbeProtocolTest(unittest.TestCase):
+    def test_transaction_accepts_only_the_verified_protocol_order(self):
+        transaction = ProbeTransaction(level=1, cell=(0, 0), index=0)
+
+        for phase in (
+            ProbePhase.REQUEST_PENDING,
+            ProbePhase.RESULT_VISIBLE,
+            ProbePhase.RESULT_RECORDED,
+            ProbePhase.REQUEST_DISCARDED,
+            ProbePhase.LOGIN_RECOVERING,
+            ProbePhase.COMPLETE,
+        ):
+            transaction.advance(phase)
+
+        self.assertEqual(transaction.phase, ProbePhase.COMPLETE)
+        self.assertFalse(transaction.request_may_be_pending)
+
+    def test_transaction_rejects_skipping_request_discard(self):
+        transaction = ProbeTransaction(level=1, cell=(0, 0), index=0)
+        transaction.advance(ProbePhase.REQUEST_PENDING)
+        transaction.advance(ProbePhase.RESULT_VISIBLE)
+        transaction.advance(ProbePhase.RESULT_RECORDED)
+
+        with self.assertRaisesRegex(ProbeProtocolError, "非法探测状态转换"):
+            transaction.advance(ProbePhase.LOGIN_RECOVERING)
+
+        self.assertTrue(transaction.request_may_be_pending)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/hit_map.py
+++ b/utils/hit_map.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from utils.diamond_centers import write_image
+
+
+def _build_cell_polygons(quad: np.ndarray, n: int) -> list[list[np.ndarray]]:
+    """根据外层菱形四角生成每个方格的四边形坐标。"""
+    src = np.array(
+        [
+            [0, 0],
+            [n, 0],
+            [n, n],
+            [0, n],
+        ],
+        dtype=np.float32,
+    )
+    matrix = cv2.getPerspectiveTransform(src, quad.astype(np.float32))
+    polygons: list[list[np.ndarray]] = []
+
+    for row in range(n):
+        polygon_row: list[np.ndarray] = []
+        for col in range(n):
+            cell = np.array(
+                [
+                    [[col, row]],
+                    [[col + 1, row]],
+                    [[col + 1, row + 1]],
+                    [[col, row + 1]],
+                ],
+                dtype=np.float32,
+            )
+            projected = cv2.perspectiveTransform(cell, matrix).reshape(4, 2)
+            polygon_row.append(np.round(projected).astype(np.int32))
+        polygons.append(polygon_row)
+
+    return polygons
+
+
+def save_hit_map_image(
+    base_img: np.ndarray,
+    quad: np.ndarray,
+    hit_map: list[list[int]],
+    out_path: str | Path,
+) -> None:
+    """把命中结果叠加绘制到游戏截图上并保存。"""
+    n = len(hit_map)
+    if n == 0 or any(len(row) != n for row in hit_map):
+        raise ValueError("hit_map 必须是非空的 N x N 列表")
+
+    out = base_img.copy()
+    overlay = out.copy()
+    polygons = _build_cell_polygons(quad, n)
+
+    for row in range(n):
+        for col in range(n):
+            if hit_map[row][col] == 1:
+                cv2.fillConvexPoly(
+                    overlay,
+                    polygons[row][col],
+                    (0, 0, 255),
+                    lineType=cv2.LINE_AA,
+                )
+
+    out = cv2.addWeighted(overlay, 0.38, out, 0.62, 0)
+
+    for row in range(n):
+        for col in range(n):
+            is_hit_cell = hit_map[row][col] == 1
+            cv2.polylines(
+                out,
+                [polygons[row][col]],
+                True,
+                (0, 0, 255) if is_hit_cell else (255, 255, 255),
+                3 if is_hit_cell else 1,
+                cv2.LINE_AA,
+            )
+
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+    write_image(out_path, out)
+
+
+__all__ = ["save_hit_map_image"]

--- a/utils/probe_protocol.py
+++ b/utils/probe_protocol.py
@@ -1,0 +1,84 @@
+from dataclasses import dataclass
+from enum import Enum, auto
+
+from utils.logger import get_logger
+from utils.submarine_strategy import Cell
+
+
+logger = get_logger(__name__)
+
+
+class ProbeProtocolError(RuntimeError):
+    """探测事务进入不安全或无法确认的状态。"""
+
+
+class ProbeNotReadyError(RuntimeError):
+    """点击发生前页面未准备好，可以安全恢复后重试当前格。"""
+
+
+class ProbePhase(Enum):
+    """单次弱网探测事务的关键阶段。"""
+
+    PREPARING = auto()
+    REQUEST_PENDING = auto()
+    RESULT_VISIBLE = auto()
+    RESULT_RECORDED = auto()
+    REQUEST_DISCARDED = auto()
+    LOGIN_RECOVERING = auto()
+    COMPLETE = auto()
+
+
+_ALLOWED_TRANSITIONS: dict[ProbePhase, set[ProbePhase]] = {
+    ProbePhase.PREPARING: {ProbePhase.REQUEST_PENDING},
+    ProbePhase.REQUEST_PENDING: {ProbePhase.RESULT_VISIBLE},
+    ProbePhase.RESULT_VISIBLE: {ProbePhase.RESULT_RECORDED},
+    ProbePhase.RESULT_RECORDED: {ProbePhase.REQUEST_DISCARDED},
+    ProbePhase.REQUEST_DISCARDED: {ProbePhase.LOGIN_RECOVERING},
+    ProbePhase.LOGIN_RECOVERING: {ProbePhase.COMPLETE},
+    ProbePhase.COMPLETE: set(),
+}
+
+
+@dataclass
+class ProbeTransaction:
+    """记录一次只能串行执行的单格弱网探测。"""
+
+    level: int
+    cell: Cell
+    index: int
+    phase: ProbePhase = ProbePhase.PREPARING
+    hit: bool | None = None
+
+    @property
+    def request_may_be_pending(self) -> bool:
+        """客户端是否仍可能保存尚未丢弃的验证请求。"""
+        return self.phase in {
+            ProbePhase.REQUEST_PENDING,
+            ProbePhase.RESULT_VISIBLE,
+            ProbePhase.RESULT_RECORDED,
+        }
+
+    def advance(self, phase: ProbePhase) -> None:
+        """按固定协议顺序推进事务，拒绝非法状态跳转。"""
+        allowed = _ALLOWED_TRANSITIONS[self.phase]
+        if phase not in allowed:
+            raise ProbeProtocolError(
+                f"非法探测状态转换: {self.phase.name} -> {phase.name}"
+            )
+
+        logger.info(
+            "第 %s 关格子 %s 探测状态：%s -> %s",
+            self.level,
+            self.index,
+            self.phase.name,
+            phase.name,
+        )
+        self.phase = phase
+
+
+__all__ = [
+    "ProbeNotReadyError",
+    "ProbePhase",
+    "ProbeProtocolError",
+    "ProbeTransaction",
+]


### PR DESCRIPTION
# refactor: 优化弱网探测流程

## PR 信息

- 分支：`feat/logic-improvements`
- 目标分支：`main`
- 提交：
  - `db8271a refactor: 优化弱网探测流程`
  - `30364c8 fix: 更新gitignore`

## 背景

项目通过 `DROP -> 二次进入读取结果 -> REJECT -> 重试登录` 的串行流程，在不让探测请求正式提交到服务器的前提下获取单格结果。

原主流程把页面导航、网络切换、单格探测、异常恢复和结果绘制混在 `main.py` 中。尤其在一次点击已经发生后，普通“重启游戏并关闭弱网”的恢复逻辑可能不适用：客户端仍可能保存待发送请求，提前恢复网络会带来请求补发和资源消耗风险。

## 改动内容

### 显式建模单次探测事务

新增 `utils/probe_protocol.py`，将一轮探测表示为固定状态序列：

```text
PREPARING
  -> REQUEST_PENDING
  -> RESULT_VISIBLE
  -> RESULT_RECORDED
  -> REQUEST_DISCARDED
  -> LOGIN_RECOVERING
  -> COMPLETE
```

- 只允许合法的相邻状态转换；
- 明确区分“点击前页面未准备好”与“点击后请求状态未知”；
- 记录当前唯一的待处理格子，避免同一时间开始第二轮探测；
- 只有出现 `retry.png` 后才进入“请求已丢弃”状态。

### 保持正常弱网协议顺序

正常成功路径仍为：

```text
DROP 已开启
  -> 点击一个格子
  -> 退出活动
  -> DROP 下二次进入并读取结果
  -> 开启 REJECT
  -> 等待 retry.png
  -> 关闭 REJECT 并点击重试
  -> 关闭 DROP，恢复网络登录
  -> 进入下一轮活动
```

本 PR 没有引入并发、批量点击或正式联网投弹。

### 失败关闭与同格重试

- 二次进入活动失败时，不再调用会关闭 DROP 的普通重启恢复流程；
- 请求仍可能待发送时，退出清理会保留 DROP，而不是无条件恢复网络；
- `retry.png` 超时会明确中止，不再解引用空匹配结果；
- 点击前页面未准备好时，恢复页面后重试同一个格子，不会跳过该格；
- 策略回退逐格扫描时会跳过已经由安全区规则推导出的格子。

### 结构整理

- 新增 `utils/hit_map.py`，承接菱形单元投影和命中图输出；
- `main.py` 只保留主流程编排、页面导航和探测事务执行；
- 模板路径和调试截图路径统一使用配置中的项目路径；
- 等待超时改用单调时钟，避免系统时间变化影响等待逻辑；
- README 补充新增模块说明；
- `.gitignore` 补充本地代理文档、代理目录和 Mypy 缓存规则。

新增测试覆盖：

- 事务状态只能按协议顺序推进；
- 不能跳过“请求已丢弃”直接进入重新登录；
- 二次进入失败不会触发普通重启恢复；
- 请求可能仍待发送时不会关闭 DROP；
- 缺少重试按钮时维持失败关闭；
- 点击前异常会重试同一格；
- 命中图模块输出和输入校验。

